### PR TITLE
(#3) Adds a default action policy allowing read only actions

### DIFF
--- a/.plugin.yaml
+++ b/.plugin.yaml
@@ -1,0 +1,6 @@
+mcollective_agent_puppet::policies:
+  - action: "allow"
+    callers: "*"
+    actions: "last_run_summary status"
+    facts: "*"
+    classes: "*"


### PR DESCRIPTION
Previously out of the box behaviour was that no actions could be
performed unless enabled, now the agent allows status and
last_run_summary out of the box while disallowing all potentially change
affecting actions