### PR TITLE
(#4) Add disable, disable_and_wait and enable plans

### DIFF
--- a/puppet/plans/disable.pp
+++ b/puppet/plans/disable.pp
@@ -1,0 +1,22 @@
+# Disables Puppet on the provided nodes
+#
+# @param nodes [Choria::Nodes] The nodes to disable
+# @param message [Optional[String]] The message to use when disabling Puppet
+# @returns [Choria::TaskResults]
+plan mcollective_agent_puppet::disable (
+  Choria::Nodes $nodes,
+  Optional[String] $message = undef
+) {
+  choria::task(
+    "action"     => "puppet.disable",
+    "nodes"      => $nodes,
+    "fail_ok"    => true,
+    "silent"     => true,
+    "properties" => {
+      "message"  => $message ? {
+        String => $message,
+        default => sprintf("Disabled using the %s playbook", $facts["choria"]["playbook"])
+      }
+    }
+  )
+}

--- a/puppet/plans/disable_and_wait.pp
+++ b/puppet/plans/disable_and_wait.pp
@@ -1,0 +1,31 @@
+# Disables Puppet on the provided nodes and wait for them to idle
+#
+# By default 10 checks will be done 20 seconds apart, you can adjust these
+# using the Playbook properties
+#
+# @param nodes [Choria::Nodes] The nodes to disable
+# @param checks [Integer] How many checks to perform
+# @param sleep [Integer] How long to wait between checks
+# @param message [Optional[String]] The message to use when disabling Puppet
+# @returns [Choria::TaskResults]
+plan mcollective_agent_puppet::disable_and_wait (
+  Choria::Nodes $nodes,
+  Integer $checks = 10,
+  Integer $sleep = 20,
+  Optional[String] $message = undef
+) {
+  choria::run_playbook("mcollective_agent_puppet::disable",
+    "message" => $message,
+    "nodes"   => $nodes
+  )
+
+  choria::task(
+    "action"    => "puppet.status",
+    "nodes"     => $nodes,
+    "assert"    => "idling=true",
+    "tries"     => $checks,
+    "try_sleep" => $sleep,
+    "silent"    => true,
+    "pre_sleep" => 5
+  )
+}

--- a/puppet/plans/enable.pp
+++ b/puppet/plans/enable.pp
@@ -1,0 +1,14 @@
+# Enables Puppet on the provided nodes
+#
+# @param nodes [Choria::Nodes] The nodes to enable
+# @returns [Choria::TaskResults]
+plan mcollective_agent_puppet::enable (
+  Choria::Nodes $nodes,
+) {
+  choria::task(
+    "action"     => "puppet.enable",
+    "nodes"      => $nodes,
+    "fail_ok"    => true,
+    "silent"     => true
+  )
+}


### PR DESCRIPTION
This add initial plans to manage the life cycle of the agent