### PR TITLE
(#7) Update documentation to make sense to Choria users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Gemfile.lock
 ext/packaging
+puppet/README.md
+puppet/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-Change history for mcollective-puppet
+Change history for `choria/mcollective_agent_puppet`
+
+## 2.0.0
+
+Released 2018-02-26
+
+ * Update documentation to be of use to Choria users (#7)
+ * Add `disable`, `enable` and `disable_and_wait` Playbooks (#4)
+ * Add default Action Policies allowing read-only actions to be used by anyone (#3)
+ * Initial release as part of the Choria Project
 
 ## 1.13.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
 #!ruby
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 group :test do
   # Pin json for Ruby < 2.0.0
-  gem 'json', '~> 1.8.3'
-  gem 'rake', '~> 10.4'
-  gem 'rspec', '~> 2.11.0'
-  gem 'mocha', '~> 0.10.0'
-  gem 'mcollective-test'
+  gem "json", "~> 1.8.3"
+  gem "rake", "~> 10.4"
+  gem "rspec", "~> 2.11.0"
+  gem "mocha", "~> 0.10.0"
+  gem "mcollective-test"
 end
 
-mcollective_version = ENV['MCOLLECTIVE_GEM_VERSION']
+mcollective_version = ENV["MCOLLECTIVE_GEM_VERSION"]
 
 if mcollective_version
-  gem 'mcollective-client', mcollective_version, :require => false
+  gem "mcollective-client", mcollective_version, :require => false
 else
-  gem 'mcollective-client', :require => false
+  gem "mcollective-client", :require => false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -19,3 +19,10 @@ task :test do
 end
 
 task :default => :test
+
+desc "Builds the release package"
+task :build do
+  cp "README.md", "puppet"
+  cp "CHANGELOG.md", "puppet"
+  sh "/opt/puppetlabs/puppet/bin/mco plugin package --format aiomodulepackage --vendor choria"
+end


### PR DESCRIPTION
This also creates `rake build` which will build the current code
after copying README.md and CHANGELOG.md to the module via the `puppet`
directory