### PR TITLE
(#10) Add a playbook to find stuck agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Additionally a number of Playbooks are included:
   * `mcollective_agent_puppet::disable` Disables the Puppet Agent
   * `mcollective_agent_puppet::disable_and_wait` Disables the Puppet Agent and wait for in-progress catalog runs to complete
   * `mcollective_agent_puppet::enable` Enables the Puppet Agent
+  * `mcollective_agent_puppet::stuck_agents` Finds agents in a stuck state that will not continue without manual intervention
 
 You can use these from other [Choria Playbooks](https://choria.io/docs/playbooks/) or on the CLI
 

--- a/puppet/plans/stuck_agents.pp
+++ b/puppet/plans/stuck_agents.pp
@@ -1,0 +1,38 @@
+# Locates agents stuck applying for extended periods of time
+#
+# When running Puppet in unstable networks one often finds a Puppet Agent stuck
+# thinking it's applying a catalog when the applying process have been in the
+# process tree for hours or days or weeks and will never die.
+#
+# This playbook detects these agents and returns a list of affected host, you could
+# use this to kill them via some other method of your choice
+#
+# @param nodes [Choria::Nodes] The nodes to limit the search on, else with the Puppet agent
+# @param maxage [Integer] Maximum amount of time between now and last completed run
+# @returns [Choria::Nodes] list of stuck nodes
+plan mcollective_agent_puppet::stuck_agents (
+  Choria::Nodes $nodes = [],
+  Integer $maxage = 7200,
+) {
+  if $nodes.empty {
+    $_nodes = choria::discover(
+      "discovery_method" => "mc",
+      "test"             => true,
+      "agents"           => ["puppet"]
+    )
+  } else {
+    $_nodes = $nodes
+  }
+
+  $stuck = choria::task(
+    "nodes"  => $_nodes,
+    "action" => "puppet.status",
+    "silent" => true,
+  ).filter |$status| {
+    $status["data"]["applying"] and $status["data"]["since_lastrun"] > $maxage
+  }.map |$status| {
+    $status.host
+  }
+
+  $stuck
+}


### PR DESCRIPTION
This queries the network for puppet agents that are in applying state
for an excessively long time, returns a node list so other playbooks
can go kill them