### PR TITLE
(#20) improve CLI usage of puppet agent plans

### DIFF
--- a/puppet/plans/disable.pp
+++ b/puppet/plans/disable.pp
@@ -4,18 +4,18 @@
 # @param message [Optional[String]] The message to use when disabling Puppet
 # @returns [Choria::TaskResults]
 plan mcollective_agent_puppet::disable (
-  Choria::Nodes $nodes,
+  Choria::Nodes $nodes = [],
   Optional[String] $message = undef
 ) {
   choria::task(
     "action"     => "puppet.disable",
-    "nodes"      => $nodes,
+    "nodes"      => choria::run_playbook("mcollective_agent_puppet::discover", "nodes" => $nodes),
     "fail_ok"    => true,
     "silent"     => true,
     "properties" => {
       "message"  => $message ? {
-        String => $message,
-        default => sprintf("Disabled using the %s playbook", $facts["choria"]["playbook"])
+        String   => $message,
+        default  => sprintf("Disabled using the %s playbook", $facts["choria"]["playbook"])
       }
     }
   )

--- a/puppet/plans/disable_and_wait.pp
+++ b/puppet/plans/disable_and_wait.pp
@@ -9,19 +9,21 @@
 # @param message [Optional[String]] The message to use when disabling Puppet
 # @returns [Choria::TaskResults]
 plan mcollective_agent_puppet::disable_and_wait (
-  Choria::Nodes $nodes,
+  Choria::Nodes $nodes = [],
   Integer $checks = 10,
   Integer $sleep = 20,
   Optional[String] $message = undef
 ) {
+  $_nodes = choria::run_playbook("mcollective_agent_puppet::discover", "nodes" => $nodes),
+
   choria::run_playbook("mcollective_agent_puppet::disable",
     "message" => $message,
-    "nodes"   => $nodes
+    "nodes"   => $_nodes
   )
 
   choria::task(
     "action"    => "puppet.status",
-    "nodes"     => $nodes,
+    "nodes"     => $_nodes,
     "assert"    => "idling=true",
     "tries"     => $checks,
     "try_sleep" => $sleep,

--- a/puppet/plans/discover.pp
+++ b/puppet/plans/discover.pp
@@ -1,0 +1,23 @@
+# Discovers nodes running Puppet
+#
+# If the nodes list is given and not empty that node
+# list will be used else a discovery will be done using
+# the users default discovery method
+#
+# Should no nodes be found an error will be raised
+#
+# @param nodes [Choria::Nodes] only discovers when this is empty
+# @return [Choria::Nodes]
+plan mcollective_agent_puppet::discover (
+  Choria::Nodes $nodes = []
+) {
+  if !$nodes.empty {
+    return $nodes
+  }
+
+  choria::discover(
+    "test"     => true,
+    "at_least" => 1,
+    "agents"   => ["puppet"]
+  )
+}

--- a/puppet/plans/enable.pp
+++ b/puppet/plans/enable.pp
@@ -3,11 +3,11 @@
 # @param nodes [Choria::Nodes] The nodes to enable
 # @returns [Choria::TaskResults]
 plan mcollective_agent_puppet::enable (
-  Choria::Nodes $nodes,
+  Choria::Nodes $nodes = [],
 ) {
   choria::task(
     "action"     => "puppet.enable",
-    "nodes"      => $nodes,
+    "nodes"      => choria::run_playbook("mcollective_agent_puppet::discover", "nodes" => $nodes),
     "fail_ok"    => true,
     "silent"     => true
   )

--- a/puppet/plans/find_stuck_agents.pp
+++ b/puppet/plans/find_stuck_agents.pp
@@ -14,15 +14,7 @@ plan mcollective_agent_puppet::find_stuck_agents (
   Choria::Nodes $nodes = [],
   Integer $maxage = 7200,
 ) {
-  if $nodes.empty {
-    $_nodes = choria::discover(
-      "discovery_method" => "mc",
-      "test"             => true,
-      "agents"           => ["puppet"]
-    )
-  } else {
-    $_nodes = $nodes
-  }
+  $_nodes = choria::run_playbook("mcollective_agent_puppet::discover", "nodes" => $nodes),
 
   $stuck = choria::task(
     "nodes"  => $_nodes,
@@ -34,5 +26,5 @@ plan mcollective_agent_puppet::find_stuck_agents (
     $status.host
   }
 
-  $stuck
+  return $stuck
 }


### PR DESCRIPTION
Previously these plans were 100% focussed on being utilities for use
by other ones but a small tweak where by they would do a discover when
nodes are not given will make this a lot more usable out of the box and
on the CLI

This adjusts all here to discover using the users default discovery
method should the node list be empty