### PR TITLE
(#29) Add support for Puppet 6

### DIFF
--- a/util/puppet_agent_mgr.rb
+++ b/util/puppet_agent_mgr.rb
@@ -51,7 +51,7 @@ module MCollective
               when "2"
                 raise "Window is not supported yet" if MCollective::Util.windows?
                 return MgrV2.new(configfile, service_name, testing)
-              when "3", "4", "5"
+              when "3", "4", "5", "6"
                 if MCollective::Util.windows?
                   return MgrWindows.new(configfile, service_name, testing)
                 else


### PR DESCRIPTION
The module seems to work as expected when Puppet 6 is installed, so make
the version test succeed with this version of Puppet.