### PR TITLE
(#32) improve resource management under json mode choria

### DIFF
--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -136,8 +136,11 @@ module MCollective
           resource_types_whitelist = ""
         end
 
+        params = {}
+        request.data.each do |k, v|
+            params[k.intern] = v
+        end
 
-        params = request.data.clone
         params.delete(:process_results)
         type = params.delete(:type).downcase
         resource_name = "%s[%s]" % [type.to_s.capitalize, params[:name]]


### PR DESCRIPTION
The agent does not use the sanctioned method of accessing request
paramters instead it clones the raw request data and then accesses
the data by symbol keys.

This is bad and incompatible with the core level JSON compatability
mitigations, we now do a loop based clone that intern each key to a
symbol instead of the deep clone