### PR TITLE
Also accept -E to set the environment

### DIFF
--- a/application/puppet.rb
+++ b/application/puppet.rb
@@ -51,7 +51,7 @@ END_OF_USAGE
          :type        => :bool
 
   option :environment,
-         :arguments   => ["--environment ENVIRONMENT"],
+         :arguments   => ["--environment ENVIRONMENT" , "-E"],
          :description => "Place the node in a specific environment for this run",
          :type        => String
 


### PR DESCRIPTION
Puppet support `-E` as a shorter alternative to `--environment`.  This
PR make it possible to use `-E` with mcollective/choria too.