### PR TITLE
Rely on Puppet 7 built-in windows utils

### DIFF
--- a/.plugin.yaml
+++ b/.plugin.yaml
@@ -1,3 +1,4 @@
+---
 mcollective_agent_puppet::policies:
   - action: "allow"
     callers: "*"

--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -29,7 +29,11 @@ module MCollective
 
       def run(command, options)
         if MCollective::Util.windows?
-          require 'win32/process'
+          unless Process.respond_to?(:create)
+            # Prior to Puppet 7 we rely on win32/process bundled with Puppet
+            # and which provide Process.create
+            require 'win32/process'
+          end
           # If creating the process doesn't outright fail, assume everything
           # was okay. The caller wants to know our exit code, so we'll just use
           # 0 or 1.


### PR DESCRIPTION
Prior to Puppet 7, the win32-process and win32-servic gems where bundled in the Puppet AIO package for windows, but where removed as Puppet gained support for these features in it's core:

  - https://github.com/puppetlabs/puppet/commit/321f36fac7856fdd8af82f80d236fb2603a825ea
  - https://github.com/puppetlabs/puppet/commit/50a908694916e812e53b5ab5b0a5302ed9ba9811

Update the code to use the new API when available, and fall-back to the previous code.

This unbreaks the module on windows with Puppet 7.

---

<details>
<summary>Initial issue before full re-write</summary>

These gem where previously installed with Puppet, but where removed from Puppet 7 bundle:
https://github.com/puppetlabs/puppet/commit/321f36fac7856fdd8af82f80d236fb2603a825ea
https://github.com/puppetlabs/puppet/commit/50a908694916e812e53b5ab5b0a5302ed9ba9811

Add them as dependencies to the agent to unbreak it on windows.

Fixes #51

Things I am not sure about:
* which version to stick to. I chose to keep the version previously used in Puppet but it might be better to update them?
* this will install the dependencies on all OSes, but it is only useful on windows. Maybe it's worth adding something to avoid installing unneeded dependencies?

</details>